### PR TITLE
Fix connection deadlock during ingest MODMS-47

### DIFF
--- a/server/src/main/java/org/folio/metastorage/server/Storage.java
+++ b/server/src/main/java/org/folio/metastorage/server/Storage.java
@@ -387,12 +387,13 @@ public class Storage {
   public Future<Void> updateGlobalRecords(LargeJsonReadStream request) {
     return pool.withConnection(conn ->
         getAvailableMatchConfigs(conn).compose(matchKeyConfigs ->
-          new ReadStreamConsumer<JsonObject, Void>()
-          .consume(request, r -> 
-            upsertGlobalRecord(
-              UUID.fromString(request.topLevelObject().getString("sourceId")), 
-              r, matchKeyConfigs))
-        ));
+          conn.close().compose(v ->
+            new ReadStreamConsumer<JsonObject, Void>()
+              .consume(request, r -> 
+                upsertGlobalRecord(
+                    UUID.fromString(request.topLevelObject().getString("sourceId")), 
+                    r, matchKeyConfigs))
+        )));
   }
 
   Future<JsonArray> getAvailableMatchConfigs(SqlConnection conn) {

--- a/server/src/main/java/org/folio/metastorage/server/Storage.java
+++ b/server/src/main/java/org/folio/metastorage/server/Storage.java
@@ -385,15 +385,12 @@ public class Storage {
    * @return async result
    */
   public Future<Void> updateGlobalRecords(LargeJsonReadStream request) {
-    return pool.withConnection(conn ->
-        getAvailableMatchConfigs(conn).compose(matchKeyConfigs ->
-          conn.close().compose(v ->
+    return pool.withConnection(this::getAvailableMatchConfigs).compose(matchKeyConfigs ->
             new ReadStreamConsumer<JsonObject, Void>()
               .consume(request, r -> 
                 upsertGlobalRecord(
                     UUID.fromString(request.topLevelObject().getString("sourceId")), 
-                    r, matchKeyConfigs))
-        )));
+                    r, matchKeyConfigs)));
   }
 
   Future<JsonArray> getAvailableMatchConfigs(SqlConnection conn) {


### PR DESCRIPTION
The connection used to read matchkey configuration was held up by the update transactions.